### PR TITLE
Fix. Make sure to check whether user has security identities set.

### DIFF
--- a/ssh_ad_keys.py
+++ b/ssh_ad_keys.py
@@ -88,14 +88,18 @@ def fetch_active_directory(ad, user):
       if int(result[1]['userAccountControl'][0]) & 0b10 != 0:
 	log('User disabled, skipping')
       else:
-        # Print found keys and add to cache
-        keys = results[0][1]['altSecurityIdentities']
-        for key in keys:
-          if key.startswith('SSHKey:') or key.startswith('sshPublicKey'):
-            key = key.replace('SSHKey:','',1)
-            key = key.replace('sshPublicKey:','',1)
-            print key
-            db.execute('INSERT INTO cached_keys (User,Key) VALUES ( ? , ? )', (user, key))
+        # Only fetch the key if user has security identities set
+        if 'altSecurityIdentities' in results[0][1]:
+            # Print found keys and add to cache
+            keys = results[0][1]['altSecurityIdentities']
+            for key in keys:
+            if key.startswith('SSHKey:') or key.startswith('sshPublicKey'):
+                key = key.replace('SSHKey:','',1)
+                key = key.replace('sshPublicKey:','',1)
+                print key
+                db.execute('INSERT INTO cached_keys (User,Key) VALUES ( ? , ? )', (user, key))
+        else:
+            log('User has no security identities set, skipping')
 
       # Save changes and exit
       db.commit()


### PR DESCRIPTION
This is to fix the case where user has no security identities set in the AD,
thus an attempt to access data stored under said key would trigger `KeyError`
exception to be risen.

Signed-off-by: Krzysztof Wilczynski krzysztof.wilczynski@linux.com
